### PR TITLE
Updated express to version 4.13.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,25 +1,20 @@
 {
   "name": "bdiscuss",
   "github": "vendethiel/bdiscuss",
-  "disabled deps": { "auto-reload-brunch": "1.7.8" },
+  "disabled deps": {
+    "auto-reload-brunch": "1.7.8"
+  },
   "dependencies": {
     "javascript-brunch": "1.7.1",
     "LiveScript-brunch": "1.6.0",
-
     "css-brunch": "1.7.0",
     "stylus-brunch": "1.8.1",
-
     "jaded-brunch": "1.7.8-hotfix",
-
     "uglify-js-brunch": "1.7.7",
     "clean-css-brunch": "1.7.2",
-
-
-
     "mysql": "2.1.0",
     "orm": "2.1.25",
-
-    "express": "3.5.0",
+    "express": "4.13.3",
     "express-resource": "1.0.0",
     "express-orm-handler": "0.0.2",
     "express-orm-api-session": "0.0.1",


### PR DESCRIPTION
:rocket:

One of your dependencies has just updated, so this PR bumps the corresponding version number in your `package.json`.

You can now check that the dependency update doesn't break your code, and then release the new version of your software safe in the knowledge that it will stay in this working state, regardless of _when_ your users do `$ npm install`.

Have a good day!
